### PR TITLE
use req.originalUrl instead of req.url

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,11 +245,11 @@ CASAuthentication.prototype._login = function(req, res, next) {
 
     // Save the return URL in the session. If an explicit return URL is set as a
     // query parameter, use that. Otherwise, just use the URL from the request.
-    req.session.cas_return_to = req.query.returnTo || url.parse(req.url).path;
+    req.session.cas_return_to = req.query.returnTo || url.parse(req.originalUrl).path;
 
     // Set up the query parameters.
     var query = {
-        service: this.service_url + url.parse(req.url).pathname,
+        service: this.service_url + url.parse(req.originalUrl).pathname,
         renew: this.renew
     };
 
@@ -292,7 +292,7 @@ CASAuthentication.prototype._handleTicket = function(req, res, next) {
 
     var requestOptions = {
         host: this.cas_host,
-        port: this.cas_port,
+        port: this.cas_port
     };
 
     if (['1.0', '2.0', '3.0'].indexOf(this.cas_version) >= 0){
@@ -300,7 +300,7 @@ CASAuthentication.prototype._handleTicket = function(req, res, next) {
         requestOptions.path = url.format({
             pathname: this.cas_path + this._validateUri,
             query: {
-                service: this.service_url + url.parse(req.url).pathname,
+                service: this.service_url + url.parse(req.originalUrl).pathname,
                 ticket: req.query.ticket
             }
         });
@@ -325,7 +325,7 @@ CASAuthentication.prototype._handleTicket = function(req, res, next) {
         requestOptions.path = url.format({
             pathname: this.cas_path + this._validateUri,
             query : {
-                TARGET : this.service_url + url.parse(req.url).pathname,
+                TARGET : this.service_url + url.parse(req.originalUrl).pathname,
                 ticket: ''
             }
         });


### PR DESCRIPTION
(this is a fix to resolve issue #7)

because req.url can be overwritten, e.g. in case of hierarchical
sub-routers in node express. When using sub-routers (delegating routes to
child routers mounted at a specific mount point in the express app), the
sub-router will only receive the "sub-URL" which is the req.originalUrl,
with the mount point of the sub-router stripped off. So, for
cas-authentication redirects to work properly, req.originalUrl has to be
used throughout.
