### PR TITLE
fixed express child route jump correct

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,11 +245,11 @@ CASAuthentication.prototype._login = function(req, res, next) {
 
     // Save the return URL in the session. If an explicit return URL is set as a
     // query parameter, use that. Otherwise, just use the URL from the request.
-    req.session.cas_return_to = req.query.returnTo || url.parse(req.url).path;
+    req.session.cas_return_to = req.query.returnTo || url.parse(req._parsedOriginalUrl || req.url).path;
 
     // Set up the query parameters.
     var query = {
-        service: this.service_url + url.parse(req.url).pathname,
+        service: this.service_url + url.parse(req._parsedOriginalUrl || req.url).pathname,
         renew: this.renew
     };
 
@@ -300,7 +300,7 @@ CASAuthentication.prototype._handleTicket = function(req, res, next) {
         requestOptions.path = url.format({
             pathname: this.cas_path + this._validateUri,
             query: {
-                service: this.service_url + url.parse(req.url).pathname,
+                service: this.service_url + url.parse(req._parsedOriginalUrl || req.url).pathname,
                 ticket: req.query.ticket
             }
         });


### PR DESCRIPTION
`var express = require('express');
var router = express.Router();
var CASAuthentication = require('cas-authentication');

var cas = new CASAuthentication({
    cas_url     : '',
    service_url : ''
});

router.get('/', cas.bounce, function(req, res, next) {
  // to
})`

例如上面代码按原来将会错误跳转，导致认证失败