### PR TITLE
fix: 使用originalUrl代替url，因为express会重写url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+***due to origin owner doesnot update origin repository, i fixed some bug in this project***
+***因为源项目作者不再维护，但是我还要使用，所以开了这个项目进行维护，修复一些bug***
+
 # Express CAS Authentication
 
 This is a CAS authentication library designed to be used with an Express server.

--- a/index.js
+++ b/index.js
@@ -245,11 +245,11 @@ CASAuthentication.prototype._login = function(req, res, next) {
 
     // Save the return URL in the session. If an explicit return URL is set as a
     // query parameter, use that. Otherwise, just use the URL from the request.
-    req.session.cas_return_to = req.query.returnTo || url.parse(req.url).path;
+    req.session.cas_return_to = req.query.returnTo || url.parse(req.originalUrl).path;
 
     // Set up the query parameters.
     var query = {
-        service: this.service_url + url.parse(req.url).pathname,
+        service: this.service_url + url.parse(req.originalUrl).pathname,
         renew: this.renew
     };
 
@@ -300,7 +300,7 @@ CASAuthentication.prototype._handleTicket = function(req, res, next) {
         requestOptions.path = url.format({
             pathname: this.cas_path + this._validateUri,
             query: {
-                service: this.service_url + url.parse(req.url).pathname,
+                service: this.service_url + url.parse(req.originalUrl).pathname,
                 ticket: req.query.ticket
             }
         });
@@ -325,7 +325,7 @@ CASAuthentication.prototype._handleTicket = function(req, res, next) {
         requestOptions.path = url.format({
             pathname: this.cas_path + this._validateUri,
             query : {
-                TARGET : this.service_url + url.parse(req.url).pathname,
+                TARGET : this.service_url + url.parse(req.originalUrl).pathname,
                 ticket: ''
             }
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cas-authentication",
-  "version": "0.0.8",
+  "name": "cas-authentication-by-alt",
+  "version": "0.0.9",
   "description": "A CAS authentication library designed to be used as middleware for an Express server.",
   "keywords": [
     "cas",


### PR DESCRIPTION
use req.originalUrl replace req.url, because express rewrite url to the mount point.
使用originalUrl代替url，因为express会重写url